### PR TITLE
feat: configurable accent/glow color with per-terminal overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ For older versions (1.2.x, 1.1.x, 1.0.x, and pre-public 2.x), see [CHANGELOG-arc
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Configurable accent/glow color** — global default (dashboard **Settings → Profiles** page, "App Accent & Glow" section) plus per-terminal overrides (tab customize popover). Reusable `AccentColorPicker` (swatches + color wheel + glow toggle) backed by `useAccentSettings()`, which persists the global default to `chrome.storage.local` (`appearanceSettings`) and mirrors it live into CSS vars (`--color-primary`/`--color-accent`/`--color-ring`) across the dashboard and sidebar via `chrome.storage.onChanged`. Per-terminal overrides are session-only (not persisted), matching existing `appearanceOverrides` behavior; resetting a terminal's overrides falls back to the global accent automatically.
+
+---
+
 ## [1.5.0] - 2026-03-30
 
 ### Added

--- a/extension/components/AccentColorPicker.tsx
+++ b/extension/components/AccentColorPicker.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { ACCENT_PRESETS } from '../styles/accent'
+
+export interface AccentColorPickerProps {
+  color: string
+  glowEnabled: boolean
+  onColorChange: (hex: string) => void
+  onGlowChange: (enabled: boolean) => void
+  label?: string
+}
+
+export function AccentColorPicker({
+  color,
+  glowEnabled,
+  onColorChange,
+  onGlowChange,
+  label = 'Accent / Glow',
+}: AccentColorPickerProps) {
+  const normalized = color.toLowerCase()
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-xs text-gray-400">{label}</div>
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {ACCENT_PRESETS.map(preset => {
+          const selected = preset.value.toLowerCase() === normalized
+          return (
+            <button
+              key={preset.value}
+              type="button"
+              title={preset.name}
+              onClick={() => onColorChange(preset.value)}
+              className={`w-5 h-5 rounded-full border transition-transform hover:scale-110 ${
+                selected ? 'border-white ring-2 ring-white/60' : 'border-white/20'
+              }`}
+              style={{ backgroundColor: preset.value }}
+            />
+          )
+        })}
+        {/* Native color wheel for any custom color */}
+        <label className="relative w-5 h-5 rounded-full border border-white/20 overflow-hidden cursor-pointer flex items-center justify-center text-[10px] text-white/70"
+               title="Custom color">
+          +
+          <input
+            aria-label="Custom color"
+            type="color"
+            value={color}
+            onInput={(e) => onColorChange((e.target as HTMLInputElement).value)}
+            className="absolute inset-0 opacity-0 cursor-pointer"
+          />
+        </label>
+      </div>
+      <label className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer select-none">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={glowEnabled}
+          aria-label="Glow"
+          onClick={() => onGlowChange(!glowEnabled)}
+          className={`w-9 h-5 rounded-full transition-colors relative ${glowEnabled ? 'bg-white/70' : 'bg-white/20'}`}
+        >
+          <span
+            className={`absolute top-0.5 w-4 h-4 rounded-full bg-black transition-transform ${
+              glowEnabled ? 'translate-x-4' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+        Glow
+      </label>
+    </div>
+  )
+}

--- a/extension/components/TerminalCustomizePopover.tsx
+++ b/extension/components/TerminalCustomizePopover.tsx
@@ -5,6 +5,8 @@ import { themes, themeNames, getBackgroundGradient as getThemeBackgroundGradient
 import { backgroundGradients, gradientNames, PANEL_COLORS, getGradientCSS, getPanelColor } from '../styles/terminal-backgrounds'
 import { FONT_FAMILIES, getAvailableFonts, type BackgroundMediaType } from './settings/types'
 import type { TerminalAppearanceOverrides } from '../hooks/useTerminalSessions'
+import { AccentColorPicker } from './AccentColorPicker'
+import { DEFAULT_ACCENT, DEFAULT_GLOW_ENABLED } from '../styles/accent'
 
 interface TerminalCustomizePopoverProps {
   sessionId: string
@@ -32,6 +34,9 @@ interface TerminalCustomizePopoverProps {
   onDecreaseFontSize: () => void
   onResetFontSize: () => void
   onClose: () => void
+  currentName?: string
+  onRename?: (sessionId: string, name: string) => void
+  accentDefaults?: { accentColor?: string; glowEnabled?: boolean }
 }
 
 const MIN_FONT_OFFSET = -4
@@ -52,6 +57,9 @@ export function TerminalCustomizePopover({
   onDecreaseFontSize,
   onResetFontSize,
   onClose,
+  currentName,
+  onRename,
+  accentDefaults,
 }: TerminalCustomizePopoverProps) {
   // Close on click outside (using shared hook)
   useOutsideClick(isOpen, useCallback(() => onClose(), [onClose]))
@@ -80,6 +88,10 @@ export function TerminalCustomizePopover({
   const effectiveBackgroundMedia = currentOverrides?.backgroundMedia ?? profileDefaults.backgroundMedia ?? ''
   const effectiveBackgroundMediaType = currentOverrides?.backgroundMediaType ?? profileDefaults.backgroundMediaType ?? 'none'
   const effectiveBackgroundMediaOpacity = currentOverrides?.backgroundMediaOpacity ?? profileDefaults.backgroundMediaOpacity ?? 50
+  const effectiveAccentColor =
+    currentOverrides?.accentColor ?? accentDefaults?.accentColor ?? DEFAULT_ACCENT
+  const effectiveGlowEnabled =
+    currentOverrides?.glowEnabled ?? accentDefaults?.glowEnabled ?? DEFAULT_GLOW_ENABLED
 
   // Compute gradient CSS same as Terminal.tsx
   const effectiveGradientCSS = effectiveGradient
@@ -204,6 +216,36 @@ export function TerminalCustomizePopover({
       </div>
 
       <div className="relative z-10 px-3 pb-3 space-y-4 max-h-96 overflow-y-auto">
+        {/* Quick rename — applies live, no Save button */}
+        {onRename && (
+          <div>
+            <label htmlFor="tcp-rename" className="block text-xs mb-1.5" style={{ color: themeColors?.brightBlack || '#888' }}>
+              Name
+            </label>
+            <input
+              id="tcp-rename"
+              aria-label="Terminal name"
+              type="text"
+              value={currentName ?? ''}
+              onChange={(e) => onRename(sessionId, e.target.value)}
+              className={`w-full px-2 py-1.5 border rounded text-sm focus:border-[#00ff88] focus:outline-none ${
+                isDark ? 'bg-[#1a1a1a] border-white/20' : 'bg-white border-gray-300'
+              }`}
+              style={{ color: themeColors?.foreground || '#e0e0e0' }}
+            />
+          </div>
+        )}
+
+        {/* Accent / glow color — applies live */}
+        <div>
+          <AccentColorPicker
+            color={effectiveAccentColor}
+            glowEnabled={effectiveGlowEnabled}
+            onColorChange={(hex) => onUpdate(sessionId, { accentColor: hex })}
+            onGlowChange={(enabled) => onUpdate(sessionId, { glowEnabled: enabled })}
+          />
+        </div>
+
         {/* Font Size */}
         <div>
           <label className="block text-xs mb-1.5" style={{ color: themeColors?.brightBlack || '#888' }}>Font Size</label>

--- a/extension/components/TerminalCustomizePopover.tsx
+++ b/extension/components/TerminalCustomizePopover.tsx
@@ -228,7 +228,7 @@ export function TerminalCustomizePopover({
               type="text"
               value={currentName ?? ''}
               onChange={(e) => onRename(sessionId, e.target.value)}
-              className={`w-full px-2 py-1.5 border rounded text-sm focus:border-[#00ff88] focus:outline-none ${
+              className={`w-full px-2 py-1.5 border rounded text-sm focus:border-white/40 focus:outline-none ${
                 isDark ? 'bg-[#1a1a1a] border-white/20' : 'bg-white border-gray-300'
               }`}
               style={{ color: themeColors?.foreground || '#e0e0e0' }}

--- a/extension/dashboard/sections/SettingsProfiles.tsx
+++ b/extension/dashboard/sections/SettingsProfiles.tsx
@@ -58,6 +58,8 @@ import {
 import FilePickerModal from '../components/files/FilePickerModal'
 import { useDragDrop } from '../../hooks/useDragDrop'
 import { spawnTerminal, spawnTerminalPopout } from '../hooks/useDashboard'
+import { useAccentSettings } from '../../hooks/useAccentSettings'
+import { AccentColorPicker } from '../../components/AccentColorPicker'
 import { useWorkingDirectory } from '../../hooks/useWorkingDirectory'
 import { getEffectiveWorkingDir } from '../../shared/utils'
 import { getEffectiveProfile } from '../../shared/profiles'
@@ -109,6 +111,9 @@ export default function SettingsProfiles() {
   // Dark mode (for preview)
   // Always use dark mode for dashboard - light mode only affects sidebar terminals
   const isDark = true
+
+  // Global accent/glow default (per-terminal overrides live in the sidebar tab customize popover)
+  const { accentColor: globalAccent, glowEnabled: globalGlow, setAccent } = useAccentSettings()
 
   // Import dialog state
   const [showImportDialog, setShowImportDialog] = useState(false)
@@ -953,6 +958,20 @@ export default function SettingsProfiles() {
             Add Profile
           </button>
         </div>
+      </div>
+
+      {/* Global Accent / Glow */}
+      <div className="mb-6 p-4 rounded-lg bg-card border border-border">
+        <h2 className="text-sm font-semibold mb-1">App Accent & Glow</h2>
+        <p className="text-xs text-muted-foreground mb-3">
+          The default highlight/glow color for terminals. Individual terminals can override this from their sidebar tab&apos;s customize (⋯) popover.
+        </p>
+        <AccentColorPicker
+          color={globalAccent}
+          glowEnabled={globalGlow}
+          onColorChange={(hex) => setAccent({ accentColor: hex })}
+          onGlowChange={(enabled) => setAccent({ glowEnabled: enabled })}
+        />
       </div>
 
       {/* Category Editor Mode */}

--- a/extension/hooks/useAccentSettings.ts
+++ b/extension/hooks/useAccentSettings.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  loadAccentSettings,
+  saveAccentSettings,
+  applyAccentToCssVars,
+  ACCENT_SETTINGS_KEY,
+  DEFAULT_ACCENT,
+  DEFAULT_GLOW_ENABLED,
+  type AccentGlobals,
+} from '../styles/accent'
+
+/**
+ * Loads + persists the GLOBAL accent default, mirrors it into dashboard CSS vars,
+ * and keeps in sync across contexts via chrome.storage.onChanged.
+ */
+export function useAccentSettings() {
+  const [globals, setGlobals] = useState<AccentGlobals>({})
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    loadAccentSettings().then(g => {
+      if (cancelled) return
+      setGlobals(g)
+      applyAccentToCssVars(g.accentColor ?? DEFAULT_ACCENT)
+      setLoaded(true)
+    })
+
+    const listener = (changes: Record<string, chrome.storage.StorageChange>) => {
+      if (changes[ACCENT_SETTINGS_KEY]) {
+        const next = (changes[ACCENT_SETTINGS_KEY].newValue as AccentGlobals) ?? {}
+        setGlobals(next)
+        applyAccentToCssVars(next.accentColor ?? DEFAULT_ACCENT)
+      }
+    }
+    chrome.storage.local.onChanged.addListener(listener)
+    return () => {
+      cancelled = true
+      chrome.storage.local.onChanged.removeListener(listener)
+    }
+  }, [])
+
+  const setAccent = useCallback((partial: AccentGlobals) => {
+    setGlobals(prev => {
+      const next = { ...prev, ...partial }
+      applyAccentToCssVars(next.accentColor ?? DEFAULT_ACCENT)
+      return next
+    })
+    void saveAccentSettings(partial)
+  }, [])
+
+  return {
+    globals,
+    accentColor: globals.accentColor ?? DEFAULT_ACCENT,
+    glowEnabled: globals.glowEnabled ?? DEFAULT_GLOW_ENABLED,
+    setAccent,
+    loaded,
+  }
+}

--- a/extension/hooks/useAccentSettings.ts
+++ b/extension/hooks/useAccentSettings.ts
@@ -22,7 +22,7 @@ export function useAccentSettings() {
     loadAccentSettings().then(g => {
       if (cancelled) return
       setGlobals(g)
-      applyAccentToCssVars(g.accentColor ?? DEFAULT_ACCENT)
+      if (g.accentColor) applyAccentToCssVars(g.accentColor)
       setLoaded(true)
     })
 
@@ -30,7 +30,7 @@ export function useAccentSettings() {
       if (changes[ACCENT_SETTINGS_KEY]) {
         const next = (changes[ACCENT_SETTINGS_KEY].newValue as AccentGlobals) ?? {}
         setGlobals(next)
-        applyAccentToCssVars(next.accentColor ?? DEFAULT_ACCENT)
+        if (next.accentColor) applyAccentToCssVars(next.accentColor)
       }
     }
     chrome.storage.local.onChanged.addListener(listener)

--- a/extension/hooks/useAccentSettings.ts
+++ b/extension/hooks/useAccentSettings.ts
@@ -43,7 +43,9 @@ export function useAccentSettings() {
   const setAccent = useCallback((partial: AccentGlobals) => {
     setGlobals(prev => {
       const next = { ...prev, ...partial }
-      applyAccentToCssVars(next.accentColor ?? DEFAULT_ACCENT)
+      // Only override the stylesheet's native --color-primary once a color is
+      // actually chosen — toggling glow alone must not force the fallback green.
+      if (next.accentColor) applyAccentToCssVars(next.accentColor)
       return next
     })
     void saveAccentSettings(partial)

--- a/extension/hooks/useTerminalSessions.ts
+++ b/extension/hooks/useTerminalSessions.ts
@@ -14,6 +14,9 @@ export interface TerminalAppearanceOverrides {
   backgroundMedia?: string
   backgroundMediaType?: BackgroundMediaType
   backgroundMediaOpacity?: number
+  // Accent / glow color (per-terminal override; falls back to global default)
+  accentColor?: string
+  glowEnabled?: boolean
 }
 
 export interface TerminalSession {

--- a/extension/sidepanel/sidepanel.tsx
+++ b/extension/sidepanel/sidepanel.tsx
@@ -48,6 +48,8 @@ import { useTabDragDrop } from '../hooks/useTabDragDrop'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { useOutsideClick } from '../hooks/useOutsideClick'
 import { useDesktopNotifications } from '../hooks/useDesktopNotifications'
+import { useAccentSettings } from '../hooks/useAccentSettings'
+import { resolveAccent, hexWithAlpha, glowShadow } from '../styles/accent'
 import { playWithPriority, type AudioPriority } from '../utils/audioManager'
 import '../styles/globals.css'
 
@@ -184,6 +186,10 @@ function SidePanelTerminal() {
     profiles,
     getNextAvailableVoice: () => getNextAvailableVoiceRef.current(),
   })
+
+  // Accent/glow settings - global defaults for per-terminal accent color resolution.
+  // Also applies the global accent to document.documentElement CSS vars on mount.
+  const { globals: accentGlobals } = useAccentSettings()
 
   // Claude status tracking - polls for Claude Code status in each terminal
   // Only terminals with "claude" in their profile command or API command will be polled
@@ -682,6 +688,16 @@ function SidePanelTerminal() {
     setContextMenu({ show: false, x: 0, y: 0, terminalId: null })
   }
 
+  // Persist a session rename. Used by the live per-keystroke rename field in the
+  // customize popover. Session state persists to chrome.storage automatically via the
+  // `sessions` effect in useTerminalSessions, so setSessions is the full persistence
+  // mechanism here - no separate storage/backend call.
+  const persistRename = (terminalId: string, name: string) => {
+    setSessions(prev => prev.map(s =>
+      s.id === terminalId ? { ...s, name } : s
+    ))
+  }
+
   // Handle "Save to Profile" from customize popover
   // Saves the current appearance overrides (and font size) to the profile
   const handleSaveToProfile = (sessionId: string) => {
@@ -1160,6 +1176,7 @@ function SidePanelTerminal() {
                   const categoryColor = getSessionCategoryColor(session, categorySettings)
                   const isSelected = currentSession === session.id
                   const isExternal = session.poppedOut || session.focusedIn3D
+                  const accent = resolveAccent(session.appearanceOverrides, accentGlobals)
 
                   return (
                   <div
@@ -1178,19 +1195,37 @@ function SidePanelTerminal() {
                           ? 'border'  // Use inline styles for category color
                           : isExternal
                             ? 'bg-blue-500/20 text-blue-300 border border-blue-500/40'
-                            : 'bg-[#00ff88]/10 text-[#00ff88] border border-[#00ff88]/30'
+                            : 'border'
                         : isExternal
                           ? 'bg-white/3 hover:bg-white/8 text-gray-500 hover:text-gray-400 border border-transparent'
                           : 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-gray-300 border border-transparent'
                       }
                       ${draggedTabId === session.id ? 'opacity-50' : ''}
-                      ${dragOverTabId === session.id ? 'border-l-2 border-l-[#00ff88]' : ''}
+                      ${dragOverTabId === session.id ? 'border-l-2' : ''}
                     `}
-                    style={isSelected && categoryColor ? {
-                      backgroundColor: `${categoryColor}20`,  // 20 = ~12% opacity in hex
-                      color: 'white',  // White text works on all category colors
-                      borderColor: `${categoryColor}60`,  // 60 = ~37% opacity in hex
-                    } : undefined}
+                    style={(() => {
+                      const dragBorder = dragOverTabId === session.id
+                        ? { borderLeftColor: accent.color } : null
+                      if (isSelected && categoryColor) {
+                        // Existing category-color behavior preserved
+                        return {
+                          backgroundColor: `${categoryColor}20`,  // 20 = ~12% opacity in hex
+                          color: 'white',  // White text works on all category colors
+                          borderColor: `${categoryColor}60`,  // 60 = ~37% opacity in hex
+                          ...dragBorder,
+                        }
+                      }
+                      if (isSelected && !isExternal) {
+                        return {
+                          backgroundColor: hexWithAlpha(accent.color, 0.1),
+                          color: accent.color,
+                          borderColor: hexWithAlpha(accent.color, 0.3),
+                          ...(accent.glow ? { boxShadow: glowShadow(accent.color) } : {}),
+                          ...dragBorder,
+                        }
+                      }
+                      return dragBorder ?? undefined
+                    })()}
                     onClick={() => switchToSession(session.id)}
                     onContextMenu={(e) => handleTabContextMenu(e, session.id)}
                     onMouseEnter={(e) => {
@@ -1270,6 +1305,23 @@ function SidePanelTerminal() {
                         </span>
                       )}
                     </span>
+                    <button
+                      type="button"
+                      aria-label="Customize terminal"
+                      title="Customize appearance"
+                      className="flex-shrink-0 opacity-0 group-hover:opacity-70 hover:!opacity-100 text-xs px-1 transition-opacity"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        const rect = e.currentTarget.getBoundingClientRect()
+                        setCustomizePopover({
+                          isOpen: true,
+                          position: { x: rect.left, y: rect.bottom + 4 },
+                          sessionId: session.id,
+                        })
+                      }}
+                    >
+                      ⋯
+                    </button>
                     <button
                       onClick={(e) => handleCloseTab(e, session.id)}
                       className="flex-shrink-0 ml-1 p-0.5 rounded hover:bg-red-500/20 transition-colors opacity-0 group-hover:opacity-100"
@@ -1718,6 +1770,9 @@ function SidePanelTerminal() {
             onDecreaseFontSize={() => decreaseFontSize(customizePopover.sessionId!)}
             onResetFontSize={() => resetFontSize(customizePopover.sessionId!)}
             onClose={() => setCustomizePopover({ isOpen: false, position: { x: 0, y: 0 }, sessionId: null })}
+            currentName={session.name}
+            onRename={persistRename}
+            accentDefaults={accentGlobals}
           />
         )
       })()}

--- a/extension/styles/accent.ts
+++ b/extension/styles/accent.ts
@@ -1,0 +1,61 @@
+// Accent / glow color resolution and persistence.
+// Single source of truth for the extension's configurable accent color.
+// Fallback is the historical green (#00ff88) so behavior is unchanged until edited.
+
+export type AccentOverride = { accentColor?: string; glowEnabled?: boolean }
+export type AccentGlobals = { accentColor?: string; glowEnabled?: boolean }
+export type ResolvedAccent = { color: string; glow: boolean }
+
+export const DEFAULT_ACCENT = '#00ff88'
+export const DEFAULT_GLOW_ENABLED = true
+export const ACCENT_SETTINGS_KEY = 'appearanceSettings'
+
+export const ACCENT_PRESETS = [
+  { name: 'Green', value: '#00ff88' },
+  { name: 'Blue', value: '#3b82f6' },
+  { name: 'Cyan', value: '#22d3ee' },
+  { name: 'Purple', value: '#a855f7' },
+  { name: 'Pink', value: '#ec4899' },
+  { name: 'Amber', value: '#f59e0b' },
+  { name: 'Red', value: '#ef4444' },
+  { name: 'White', value: '#ffffff' },
+] as const
+
+/** Per-terminal override wins, else global default, else green fallback. */
+export function resolveAccent(override: AccentOverride | undefined, globals: AccentGlobals): ResolvedAccent {
+  return {
+    color: override?.accentColor ?? globals.accentColor ?? DEFAULT_ACCENT,
+    glow: override?.glowEnabled ?? globals.glowEnabled ?? DEFAULT_GLOW_ENABLED,
+  }
+}
+
+/** Convert a #rrggbb hex + alpha (0..1) into #rrggbbAA. */
+export function hexWithAlpha(hex: string, alpha: number): string {
+  const clamped = Math.max(0, Math.min(1, alpha))
+  const a = Math.round(clamped * 255).toString(16).padStart(2, '0')
+  return `${hex}${a}`
+}
+
+/** Soft two-layer glow used on the active terminal row. */
+export function glowShadow(hex: string): string {
+  return `0 0 12px ${hexWithAlpha(hex, 0.5)}, 0 0 4px ${hexWithAlpha(hex, 0.35)}`
+}
+
+/** Read the persisted global accent settings (empty object if unset). */
+export async function loadAccentSettings(): Promise<AccentGlobals> {
+  const result = await chrome.storage.local.get(ACCENT_SETTINGS_KEY)
+  return (result?.[ACCENT_SETTINGS_KEY] as AccentGlobals) ?? {}
+}
+
+/** Merge-and-persist a partial update to the global accent settings. */
+export async function saveAccentSettings(partial: AccentGlobals): Promise<void> {
+  const current = await loadAccentSettings()
+  await chrome.storage.local.set({ [ACCENT_SETTINGS_KEY]: { ...current, ...partial } })
+}
+
+/** Mirror the accent color into the dashboard CSS variables so .terminal-glow / .border-glow recolor. */
+export function applyAccentToCssVars(color: string, root: HTMLElement = document.documentElement): void {
+  root.style.setProperty('--color-primary', color)
+  root.style.setProperty('--color-accent', color)
+  root.style.setProperty('--color-ring', color)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -596,7 +595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -640,7 +638,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1738,7 +1735,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -2639,7 +2635,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2816,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2828,7 +2824,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2862,7 +2857,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
       "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3038,7 +3032,6 @@
       "integrity": "sha512-F9jI5rSstNknPlTlPN2gcc4gpbaagowuRzw/OJzl368dvPun668Q182S8Q8P9PITgGCl5LAKXpzuue106eM4wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.8",
         "fflate": "^0.8.2",
@@ -3131,8 +3124,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -3183,6 +3175,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3193,6 +3186,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3378,7 +3372,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3984,7 +3977,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5501,6 +5495,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6815,7 +6810,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6843,7 +6837,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6872,6 +6865,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6886,7 +6880,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -6964,7 +6959,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6989,7 +6983,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7625,8 +7618,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -7656,8 +7648,7 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
       "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -8152,7 +8143,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -8213,7 +8203,6 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",
@@ -8752,7 +8741,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/tests/unit/components/AccentColorPicker.test.tsx
+++ b/tests/unit/components/AccentColorPicker.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { AccentColorPicker } from '../../../extension/components/AccentColorPicker'
+
+function setup(overrides = {}) {
+  const onColorChange = vi.fn()
+  const onGlowChange = vi.fn()
+  render(
+    <AccentColorPicker
+      color="#00ff88"
+      glowEnabled={true}
+      onColorChange={onColorChange}
+      onGlowChange={onGlowChange}
+      {...overrides}
+    />
+  )
+  return { onColorChange, onGlowChange }
+}
+
+describe('AccentColorPicker', () => {
+  it('renders a swatch per preset', () => {
+    setup()
+    // Blue preset swatch is reachable by its title
+    expect(screen.getByTitle('Blue')).toBeTruthy()
+    expect(screen.getByTitle('White')).toBeTruthy()
+  })
+
+  it('clicking a preset calls onColorChange with that hex', () => {
+    const { onColorChange } = setup()
+    fireEvent.click(screen.getByTitle('Blue'))
+    expect(onColorChange).toHaveBeenCalledWith('#3b82f6')
+  })
+
+  it('changing the native color input calls onColorChange', () => {
+    const { onColorChange } = setup()
+    const input = screen.getByLabelText('Custom color') as HTMLInputElement
+    fireEvent.input(input, { target: { value: '#123456' } })
+    expect(onColorChange).toHaveBeenCalledWith('#123456')
+  })
+
+  it('toggling glow calls onGlowChange with the new value', () => {
+    const { onGlowChange } = setup()
+    fireEvent.click(screen.getByRole('switch', { name: /glow/i }))
+    expect(onGlowChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/tests/unit/components/TerminalCustomizePopover.accent.test.tsx
+++ b/tests/unit/components/TerminalCustomizePopover.accent.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { TerminalCustomizePopover } from '../../../extension/components/TerminalCustomizePopover'
+
+function renderPopover(extra = {}) {
+  const onUpdate = vi.fn()
+  const onReset = vi.fn()
+  const onRename = vi.fn()
+  render(
+    <TerminalCustomizePopover
+      sessionId="ctt-default-abcd1234"
+      isOpen={true}
+      position={{ x: 10, y: 10 }}
+      currentOverrides={undefined}
+      profileDefaults={{}}
+      currentName="My Term"
+      onRename={onRename}
+      accentDefaults={{ accentColor: '#00ff88', glowEnabled: true }}
+      onUpdate={onUpdate}
+      onReset={onReset}
+      onIncreaseFontSize={() => {}}
+      onDecreaseFontSize={() => {}}
+      onResetFontSize={() => {}}
+      onClose={() => {}}
+      {...extra}
+    />
+  )
+  return { onUpdate, onReset, onRename }
+}
+
+describe('TerminalCustomizePopover accent additions', () => {
+  it('renders the rename field with the current name', () => {
+    renderPopover()
+    const input = screen.getByLabelText('Terminal name') as HTMLInputElement
+    expect(input.value).toBe('My Term')
+  })
+
+  it('typing in the rename field calls onRename live', () => {
+    const { onRename } = renderPopover()
+    fireEvent.change(screen.getByLabelText('Terminal name'), { target: { value: 'Renamed' } })
+    expect(onRename).toHaveBeenCalledWith('ctt-default-abcd1234', 'Renamed')
+  })
+
+  it('choosing an accent preset calls onUpdate with accentColor', () => {
+    const { onUpdate } = renderPopover()
+    fireEvent.click(screen.getByTitle('Blue'))
+    expect(onUpdate).toHaveBeenCalledWith('ctt-default-abcd1234', { accentColor: '#3b82f6' })
+  })
+
+  it('toggling glow calls onUpdate with glowEnabled', () => {
+    const { onUpdate } = renderPopover()
+    fireEvent.click(screen.getByRole('switch', { name: /glow/i }))
+    expect(onUpdate).toHaveBeenCalledWith('ctt-default-abcd1234', { glowEnabled: false })
+  })
+})

--- a/tests/unit/hooks/useAccentSettings.test.ts
+++ b/tests/unit/hooks/useAccentSettings.test.ts
@@ -36,4 +36,11 @@ describe('useAccentSettings', () => {
     await waitFor(() =>
       expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('#3b82f6'))
   })
+
+  it('does not touch --color-primary when storage is empty', async () => {
+    document.documentElement.style.removeProperty('--color-primary')
+    const { result } = renderHook(() => useAccentSettings())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('')
+  })
 })

--- a/tests/unit/hooks/useAccentSettings.test.ts
+++ b/tests/unit/hooks/useAccentSettings.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { resetChromeStorage, setChromeStorageData, getChromeStorageData } from '../../setup'
+import { useAccentSettings } from '../../../extension/hooks/useAccentSettings'
+import { ACCENT_SETTINGS_KEY, DEFAULT_ACCENT } from '../../../extension/styles/accent'
+
+describe('useAccentSettings', () => {
+  beforeEach(() => resetChromeStorage())
+
+  it('defaults to green when storage empty', async () => {
+    const { result } = renderHook(() => useAccentSettings())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.accentColor).toBe(DEFAULT_ACCENT)
+    expect(result.current.glowEnabled).toBe(true)
+  })
+
+  it('loads persisted settings', async () => {
+    setChromeStorageData({ [ACCENT_SETTINGS_KEY]: { accentColor: '#3b82f6', glowEnabled: false } })
+    const { result } = renderHook(() => useAccentSettings())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.accentColor).toBe('#3b82f6')
+    expect(result.current.glowEnabled).toBe(false)
+  })
+
+  it('setAccent persists and updates state', async () => {
+    const { result } = renderHook(() => useAccentSettings())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    act(() => { result.current.setAccent({ accentColor: '#ffffff' }) })
+    await waitFor(() => expect(result.current.accentColor).toBe('#ffffff'))
+    expect(getChromeStorageData()[ACCENT_SETTINGS_KEY]).toMatchObject({ accentColor: '#ffffff' })
+  })
+
+  it('applies the accent to document CSS variables', async () => {
+    setChromeStorageData({ [ACCENT_SETTINGS_KEY]: { accentColor: '#3b82f6' } })
+    renderHook(() => useAccentSettings())
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('#3b82f6'))
+  })
+})

--- a/tests/unit/hooks/useAccentSettings.test.ts
+++ b/tests/unit/hooks/useAccentSettings.test.ts
@@ -43,4 +43,13 @@ describe('useAccentSettings', () => {
     await waitFor(() => expect(result.current.loaded).toBe(true))
     expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('')
   })
+
+  it('toggling glow before any color is picked does not force the fallback CSS var', async () => {
+    document.documentElement.style.removeProperty('--color-primary')
+    const { result } = renderHook(() => useAccentSettings())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    act(() => { result.current.setAccent({ glowEnabled: false }) })
+    await waitFor(() => expect(result.current.glowEnabled).toBe(false))
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('')
+  })
 })

--- a/tests/unit/styles/accent.test.ts
+++ b/tests/unit/styles/accent.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resetChromeStorage, setChromeStorageData, getChromeStorageData } from '../../setup'
+import {
+  resolveAccent,
+  hexWithAlpha,
+  glowShadow,
+  loadAccentSettings,
+  saveAccentSettings,
+  applyAccentToCssVars,
+  DEFAULT_ACCENT,
+  DEFAULT_GLOW_ENABLED,
+  ACCENT_SETTINGS_KEY,
+  ACCENT_PRESETS,
+} from '../../../extension/styles/accent'
+
+describe('resolveAccent', () => {
+  it('falls back to default green when nothing set', () => {
+    expect(resolveAccent(undefined, {})).toEqual({ color: DEFAULT_ACCENT, glow: DEFAULT_GLOW_ENABLED })
+  })
+  it('uses global when no per-terminal override', () => {
+    expect(resolveAccent(undefined, { accentColor: '#3b82f6', glowEnabled: false }))
+      .toEqual({ color: '#3b82f6', glow: false })
+  })
+  it('per-terminal override wins over global', () => {
+    expect(resolveAccent({ accentColor: '#ffffff' }, { accentColor: '#3b82f6' }))
+      .toEqual({ color: '#ffffff', glow: DEFAULT_GLOW_ENABLED })
+  })
+  it('resolves glow independently of color', () => {
+    expect(resolveAccent({ glowEnabled: false }, { accentColor: '#3b82f6', glowEnabled: true }))
+      .toEqual({ color: '#3b82f6', glow: false })
+  })
+})
+
+describe('hexWithAlpha', () => {
+  it('appends a 2-digit alpha for full opacity', () => {
+    expect(hexWithAlpha('#00ff88', 1)).toBe('#00ff88ff')
+  })
+  it('computes ~12% alpha', () => {
+    expect(hexWithAlpha('#00ff88', 0.12)).toBe('#00ff881f')
+  })
+  it('clamps out-of-range alpha', () => {
+    expect(hexWithAlpha('#00ff88', 2)).toBe('#00ff88ff')
+    expect(hexWithAlpha('#00ff88', -1)).toBe('#00ff8800')
+  })
+})
+
+describe('glowShadow', () => {
+  it('includes the color and a blur radius', () => {
+    const s = glowShadow('#3b82f6')
+    expect(s).toContain('#3b82f6')
+    expect(s).toMatch(/px/)
+  })
+})
+
+describe('storage', () => {
+  beforeEach(() => resetChromeStorage())
+  it('returns empty object when unset', async () => {
+    expect(await loadAccentSettings()).toEqual({})
+  })
+  it('round-trips saved settings and merges partials', async () => {
+    await saveAccentSettings({ accentColor: '#3b82f6' })
+    await saveAccentSettings({ glowEnabled: false })
+    expect(await loadAccentSettings()).toEqual({ accentColor: '#3b82f6', glowEnabled: false })
+    expect(getChromeStorageData()[ACCENT_SETTINGS_KEY]).toEqual({ accentColor: '#3b82f6', glowEnabled: false })
+  })
+})
+
+describe('applyAccentToCssVars', () => {
+  it('sets --color-primary/accent/ring on the given root', () => {
+    const el = document.createElement('div')
+    applyAccentToCssVars('#3b82f6', el)
+    expect(el.style.getPropertyValue('--color-primary')).toBe('#3b82f6')
+    expect(el.style.getPropertyValue('--color-accent')).toBe('#3b82f6')
+    expect(el.style.getPropertyValue('--color-ring')).toBe('#3b82f6')
+  })
+})
+
+describe('presets', () => {
+  it('includes green, blue and white', () => {
+    const values = ACCENT_PRESETS.map(p => p.value.toLowerCase())
+    expect(values).toContain('#00ff88')
+    expect(values).toContain('#3b82f6')
+    expect(values).toContain('#ffffff')
+  })
+})


### PR DESCRIPTION
## What

Makes the extension's signature green (`#00ff88`) accent configurable — a global default in the dashboard (**Settings → Profiles → "App Accent & Glow"**) plus optional per-terminal overrides in each sidebar tab's customize (⋯) popover. Includes an optional glow toggle for the active-tab shadow.

## How it works

- `extension/styles/accent.ts` — small core module: resolution precedence is **per-terminal override → global setting → `#00ff88` fallback**, so anyone who never touches the feature sees exactly the current look.
- `useAccentSettings()` hook persists the global default to `chrome.storage.local` and live-syncs across extension contexts via `chrome.storage.onChanged`. The chosen color is mirrored into the existing `--color-primary` / `--color-accent` / `--color-ring` CSS vars so `.terminal-glow` etc. recolor with it.
- `AccentColorPicker` — reusable component (8 preset swatches + native color wheel + glow switch). No new dependencies.
- Per-terminal overrides ride the existing `appearanceOverrides` mechanism (two new optional fields), so they're session-scoped exactly like the other appearance overrides.

## Design notes

- **Category colors still win** over the accent when both apply to a selected tab — existing behavior preserved.
- **Storage changes are additive only** (two optional fields on `TerminalAppearanceOverrides`, one new `appearanceSettings` key) — no schema break, fits as a `1.x.0` minor per CONTRIBUTING/versioning rules.
- The tab strip's hardcoded `#00ff88` Tailwind classes become inline styles driven by the resolver; visual output is identical at the default.

## Testing

- 4 new unit test files (resolver, hook, picker, popover integration); full suite passes: **947/947**.
- `tsc --noEmit` clean, `npm run build` clean.
- Exercised manually in Chrome: global picker recolors dashboard + sidebar live; per-terminal override and reset-to-global behave as described; glow toggle works independently of color choice.
