### PR TITLE
fix: ResizeObserver disconnected after init — terminals ignored container-only resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ For older versions (1.2.x, 1.1.x, 1.0.x, and pre-public 2.x), see [CHANGELOG-arc
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Terminals ignored container-only resizes** (`extension/components/Terminal.tsx`) — the ResizeObserver was created inside the xterm init effect. When `isInitialized` flipped to true that effect re-ran: React executed the previous cleanup first (disconnecting the observer) and the re-run's early-return guard never re-created it, so every terminal ran with a dead observer from moments after mount. Window resizes were covered by a separate listener, but container-only changes (banners appearing/disappearing, layout shifts) left xterm at stale dimensions. The observer now lives in its own effect keyed on `isInitialized`, with symmetric setup/cleanup.
+
+---
+
 ## [1.5.0] - 2026-03-30
 
 ### Added

--- a/extension/components/Terminal.tsx
+++ b/extension/components/Terminal.tsx
@@ -83,6 +83,7 @@ export function Terminal({ terminalId, sessionName, terminalType = 'bash', worki
   const xtermRef = useRef<XTerm | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const canvasAddonRef = useRef<CanvasAddon | null>(null)
+  const fitTerminalRef = useRef<((retryCount?: number, sendToBackend?: boolean) => void) | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [isInitialized, setIsInitialized] = useState(false)  // Track if xterm has been opened
   const [mediaError, setMediaError] = useState(false)  // Track if background media failed to load
@@ -515,6 +516,9 @@ export function Terminal({ terminalId, sessionName, terminalType = 'bash', worki
         flushWriteQueue()
       }
     }
+    // Expose to the standalone ResizeObserver effect (which outlives this
+    // effect's re-runs — see the observer effect below).
+    fitTerminalRef.current = fitTerminal
 
     // Initial fit sequence after xterm.open()
     const initialFit = () => {
@@ -699,24 +703,30 @@ export function Terminal({ terminalId, sessionName, terminalType = 'bash', worki
       xterm.focus()
     }, 150)
 
-    // ResizeObserver to fit when container size changes
-    // SIMPLIFIED: Following Tabz pattern - for tmux sessions, only do local fit, don't send resize to backend
-    // Backend resize is only sent on actual window resize events (handled separately)
-    const resizeObserverTimeoutRef = { current: null as ReturnType<typeof setTimeout> | null }
+  }, [terminalId, isInitialized])
 
+  // ResizeObserver to fit when container size changes.
+  // SIMPLIFIED: Following Tabz pattern - for tmux sessions, only do local fit, don't send resize to backend.
+  // Backend resize is only sent on actual window resize events (handled separately).
+  //
+  // Lives in its OWN effect, not the init effect above: the init effect re-runs
+  // when isInitialized flips to true, and React runs the previous cleanup first.
+  // When the observer lived inside it, that cleanup disconnected the observer
+  // while the re-run's early-return guard never re-created it — so container
+  // resizes (orientation toggle, panel layout changes) were silently ignored.
+  useEffect(() => {
+    if (!isInitialized || !terminalRef.current) return
+
+    let debounce: ReturnType<typeof setTimeout> | null = null
     const resizeObserver = new ResizeObserver((entries) => {
-      if (resizeObserverTimeoutRef.current) clearTimeout(resizeObserverTimeoutRef.current)
-
       const entry = entries[0]
       if (!entry || entry.contentRect.width <= 0 || entry.contentRect.height <= 0) {
         return
       }
 
-      // Only log occasionally to reduce spam
-      // console.log(`[Terminal] ${terminalId.slice(-8)} RESIZE_OBSERVER fired: ${Math.round(entry.contentRect.width)}x${Math.round(entry.contentRect.height)}`)
-
       // Debounce the fit operation
-      resizeObserverTimeoutRef.current = setTimeout(() => {
+      if (debounce) clearTimeout(debounce)
+      debounce = setTimeout(() => {
         if (!xtermRef.current || !fitAddonRef.current || !terminalRef.current) return
 
         // For tmux sessions, just fit and trigger resize trick - don't clear
@@ -726,7 +736,7 @@ export function Terminal({ terminalId, sessionName, terminalType = 'bash', worki
           const beforeCols = xtermRef.current.cols
           const beforeRows = xtermRef.current.rows
 
-          fitTerminal(0, false)
+          fitTerminalRef.current?.(0, false)
 
           const afterCols = xtermRef.current.cols
           const afterRows = xtermRef.current.rows
@@ -752,23 +762,17 @@ export function Terminal({ terminalId, sessionName, terminalType = 'bash', worki
         }
 
         // Non-tmux sessions: just fit
-        fitTerminal(0, false)
+        fitTerminalRef.current?.(0, false)
       }, 150)
     })
 
-    if (terminalRef.current) {
-      resizeObserver.observe(terminalRef.current)
-    }
-
-    // Cleanup
-    const currentResizeObserver = resizeObserver
-    const currentTimeoutRef = resizeObserverTimeoutRef
+    resizeObserver.observe(terminalRef.current)
 
     return () => {
-      currentResizeObserver.disconnect()
-      if (currentTimeoutRef.current) clearTimeout(currentTimeoutRef.current)
+      resizeObserver.disconnect()
+      if (debounce) clearTimeout(debounce)
     }
-  }, [terminalId, isInitialized])
+  }, [terminalId, isInitialized, isTmuxSession])
 
   // Separate cleanup effect - only dispose xterm on true unmount
   useEffect(() => {


### PR DESCRIPTION
## What

Fixes terminals silently ignoring container-only resizes. The `ResizeObserver` in `Terminal.tsx` was created inside the xterm init effect — the same effect that flips `isInitialized` to true. When that state flip re-ran the effect, React executed the previous invocation's cleanup first (disconnecting the observer), and the re-run's early-return guard (`if (isInitialized || ...) return`) never created a replacement. Net effect: **every terminal ran with a dead observer from moments after mount.**

Window resizes were covered by the separate `window.addEventListener('resize')` handler, which masked the bug most of the time. But container-only changes — a banner appearing/disappearing above the terminal area, or any layout shift that resizes the terminal's parent without resizing the window — left xterm at stale cols/rows (clipped or letterboxed content).

## How

The observer now lives in its own `useEffect` keyed on `[terminalId, isInitialized, isTmuxSession]`, with symmetric setup/cleanup — it registers once the terminal is initialized and survives until unmount. The callback body is unchanged (same debounce, same tmux fit + resize-trick + narrowing-clear behavior). `fitTerminal` stays defined in the init effect and is shared via a ref.

## How verified

- Instrumented repro in a Playwright-driven browser with the unpacked extension: before the fix, a tagged container grew 276px → 452px with zero observer callbacks (while an independently-injected observer on the same node fired); after the fix, xterm's screen width tracks the container in both directions of a layout change.
- `tsc --noEmit` clean, `npm test` 921/921, `npm run build` clean.
