### PR TITLE
fix: sanitize stale tmux pane mouse/alt-screen modes before attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For older versions (1.2.x, 1.1.x, 1.0.x, and pre-public 2.x), see [CHANGELOG-archive.md](CHANGELOG-archive.md).
 
+## [Unreleased]
+
+### Fixed
+
+- **Mouse-wheel escape sequences (`64;22;46M…`) typed into shell prompts after a TUI app dies** (`backend/modules/pty-handler.js`) — when a full-screen app (e.g. a Claude session) is killed without restoring the terminal, tmux keeps the pane's mouse/alt-screen state, re-asserts it to each newly-attached client, and forwards the resulting wheel reports into the pane — where the now-bare shell echoes them as garbage. The backend now sanitizes before attach: panes whose current command is a plain shell but which still advertise mouse or alt-screen modes get DECRST resets written to their tty, which tmux parses as application output and clears its stale pane state.
+
 ---
 
 ## [1.5.0] - 2026-03-30

--- a/backend/modules/pty-handler.js
+++ b/backend/modules/pty-handler.js
@@ -85,6 +85,37 @@ class PTYHandler extends EventEmitter {
   /**
    * Generate a unique tmux session name
    */
+  /**
+   * Heal stale pane modes left behind by abruptly-killed TUI apps (e.g. a dead
+   * Claude session). Tmux keeps the pane's mouse/alt-screen state and re-asserts
+   * it to every newly-attached client, so xterm.js starts sending wheel reports
+   * that tmux forwards into a pane now running a plain shell — which echoes them
+   * as ";64;22;46M" garbage at the prompt. If a pane runs a bare shell but still
+   * advertises mouse/alt-screen modes, write DECRST resets to the pane tty: tmux
+   * parses them as application output and clears its own pane state.
+   */
+  sanitizeStalePaneModes(sessionName) {
+    try {
+      const out = require('child_process').execFileSync(
+        'tmux',
+        ['list-panes', '-t', sessionName, '-F', '#{pane_current_command}|#{mouse_any_flag}|#{alternate_on}|#{pane_tty}'],
+        { encoding: 'utf8' }
+      );
+      const SHELLS = new Set(['bash', 'zsh', 'sh', 'fish', 'dash']);
+      for (const line of out.trim().split('\n')) {
+        const [cmd, mouse, alt, tty] = line.split('|');
+        if (!tty || !SHELLS.has((cmd || '').replace(/^-/, ''))) continue;
+        if (mouse === '1' || alt === '1') {
+          log.info(`Sanitizing stale pane modes on ${sessionName} (${cmd}, mouse=${mouse}, alt=${alt})`);
+          require('fs').writeFileSync(tty, '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1049l');
+        }
+      }
+    } catch (e) {
+      // Best-effort: never block an attach on sanitization
+      log.debug(`sanitizeStalePaneModes skipped: ${e.message}`);
+    }
+  }
+
   generateUniqueSessionName(baseName) {
     if (!this.tmuxSessionExists(baseName)) {
       return baseName;
@@ -295,6 +326,11 @@ class PTYHandler extends EventEmitter {
             throw new Error(`Failed to create tmux session: ${tmuxError.message}`);
           }
         }
+
+        // Heal any stale mouse/alt-screen pane state before a client attaches,
+        // so reconnecting to a session whose TUI app died doesn't spray mouse
+        // reports into the shell.
+        this.sanitizeStalePaneModes(sessionName);
 
         // Attach to the tmux session via PTY (works for both new and existing)
         ptyProcess = pty.spawn('tmux', ['attach-session', '-t', sessionName], {


### PR DESCRIPTION
## What

Fixes mouse-wheel escape garbage (`64;22;46M`-style fragments) being typed into shell prompts after a full-screen TUI app dies inside a tmux session.

When an app that enabled mouse tracking (e.g. a Claude Code session) is killed without restoring the terminal, tmux keeps the pane's mouse/alt-screen state. It then re-asserts those modes to every newly-attached client — so xterm.js starts emitting SGR wheel reports — and forwards those reports *into the pane*, where the now-bare shell echoes them as junk (readline eats the `\e[<` prefix, leaving `64;x;yM` fragments on the prompt line). Every scroll adds more.

Observable signature: `tmux list-panes -F '#{pane_current_command} #{mouse_any_flag} #{alternate_on}'` shows a plain shell with `mouse_any=1` and/or `alternate_on=1`.

## How

`pty-handler.js` gains `sanitizeStalePaneModes(sessionName)`, called just before each `tmux attach-session`. For any pane whose current command is a bare shell (`bash|zsh|sh|fish|dash`) but which still advertises mouse or alt-screen modes, it writes DECRST resets (`?1000l ?1002l ?1003l ?1006l ?2004l ?1049l`) to the pane's tty. tmux parses these as application output and clears its stale pane state. Best-effort: failures are logged at debug and never block the attach. Panes running live TUIs are untouched (their command isn't a shell).

## How verified

- Reproduced on a live session with a killed Claude pane: `mouse_any=1 alt=1` with `cmd=zsh`, scroll spraying reports into the prompt. Writing the DECRST string to the pane tty flipped the flags to `mouse_any=0 alt=0` and stopped the garbage immediately.
- `npm test` 921/921 (root) and backend suite pass.
